### PR TITLE
fix: bind password flag to viper (closes #55)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func init() {
 	mustBindFlag("host", rootCmd.PersistentFlags().Lookup("host"))
 	mustBindFlag("port", rootCmd.PersistentFlags().Lookup("port"))
 	mustBindFlag("user", rootCmd.PersistentFlags().Lookup("user"))
+	mustBindFlag("password", rootCmd.PersistentFlags().Lookup("password"))
 	mustBindFlag("database", rootCmd.PersistentFlags().Lookup("database"))
 	mustBindFlag("socket", rootCmd.PersistentFlags().Lookup("socket"))
 	mustBindFlag("format", rootCmd.PersistentFlags().Lookup("format"))
@@ -98,6 +99,9 @@ func initConfig() {
 		}
 		if !rootCmd.PersistentFlags().Changed("user") && viper.IsSet("connections.default.user") {
 			viper.Set("user", viper.GetString("connections.default.user"))
+		}
+		if !rootCmd.PersistentFlags().Changed("password") && viper.IsSet("connections.default.password") {
+			viper.Set("password", viper.GetString("connections.default.password"))
 		}
 		if !rootCmd.PersistentFlags().Changed("database") && viper.IsSet("connections.default.database") {
 			viper.Set("database", viper.GetString("connections.default.database"))


### PR DESCRIPTION
## Summary
- Bind the `password` CLI flag to viper via `mustBindFlag`, matching all other connection flags
- Add config file mapping for `connections.default.password` in `initConfig()`

This was the only connection flag not bound to viper, so `--password=value` and `-p value` were silently ignored — only `DBSAFE_PASSWORD` env var worked.

The `NoOptDefVal = ""` behavior is preserved: `-p` without a value still triggers the interactive prompt.

Closes #55

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` — all tests pass
- [ ] Manual: `./dbsafe plan --password=dbsafe_demo -H 127.0.0.1 -P 23306 -u dbsafe -d demo "ALTER TABLE orders ADD COLUMN test_col INT"` connects without prompting
- [ ] Manual: `./dbsafe plan -p dbsafe_demo -H 127.0.0.1 -P 23306 -u dbsafe -d demo "ALTER TABLE orders ADD COLUMN test_col INT"` connects without prompting
- [ ] Manual: `./dbsafe plan -p -H 127.0.0.1 -P 23306 -u dbsafe -d demo "ALTER TABLE orders ADD COLUMN test_col INT"` still prompts for password